### PR TITLE
Fix: Ensure correct JavaScript MIME types in .htaccess

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -13,7 +13,8 @@ RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule . /index.html [L]
 
 # MIME Types for modern web assets
-AddType application/javascript .js
+AddType text/javascript .js
+AddType text/javascript .mjs
 AddType text/css .css
 AddType image/svg+xml .svg
 


### PR DESCRIPTION
I've modified .htaccess to use `text/javascript` for .js and .mjs files. This is to resolve an issue where JavaScript modules were being served with an incorrect MIME type (`application/octet-stream`), causing them to fail to load in the browser.

I also investigated a `content.js` error and concluded it is likely due to a browser extension, providing recommendations to you for troubleshooting.